### PR TITLE
Add Support for BIF URL

### DIFF
--- a/source/main.brs
+++ b/source/main.brs
@@ -892,6 +892,15 @@ sub playVideo(screen as Object, auth As Object, adsEnabled = false, content = in
       playerInfo.video.video_content_genre = m.global.video_content_genre
   end if
 
+  if (playerInfo.bif <> invalid)
+      content.SDBifUrl = playerInfo.bif.sd
+      content.HDBifUrl = playerInfo.bif.hd
+      content.FHDBifUrl = playerInfo.bif.fhd
+  else
+      content.SDBifUrl = ""
+      content.HDBifUrl = ""
+      content.FHDBifUrl = ""
+  end if
   print "--------------------------------------------------------------------------4"
 
   content.stream = playerInfo.stream

--- a/source/zype_api.brs
+++ b/source/zype_api.brs
@@ -604,11 +604,16 @@ Function GetPlayerInfo(videoid As String, urlParams = {} As Object) As Object
       end if
 
       if video.DoesExist("title")
-        info.video.title = video.title
+          info.video.title = video.title
       end if
 
       if video.DoesExist("duration")
-        info.video.duration = video.duration
+          info.video.duration = video.duration
+      end if
+
+      if response.body.DoesExist("bif")
+          info.bif = response.body.bif
+          print "info.bif ::: " info.bif
       end if
 
       ' Set VideoID'


### PR DESCRIPTION
Support for Trick Play is a new Roku certification requirement as of September 30, 2020. 
Adding support for BIF URL will allow customer applications to pass marketplace certification for Trick Play.