### PR TITLE
Poster second line title fix

### DIFF
--- a/components/screens/GridScreen/GridScreen.xml
+++ b/components/screens/GridScreen/GridScreen.xml
@@ -134,7 +134,7 @@
             id="RowList"
             itemComponentName="GridScreenItem"
             focusBitmapUri="pkg:/images/focus_grid_light.9.png"
-            translation="[-60, 410]"
+            translation="[-60, 404]"
             itemSize="[1327, 262]"
             numRows="2"
             itemSpacing="[0,0]"


### PR DESCRIPTION
Fixed second line of the video title is getting cut on playlist.